### PR TITLE
Add an index keyed on client reference

### DIFF
--- a/src/rexi_server.erl
+++ b/src/rexi_server.erl
@@ -89,8 +89,12 @@ handle_cast(_, St) ->
     {noreply, St}.
 
 handle_info({'DOWN', Ref, process, _, normal}, #st{workers=Workers} = St) ->
-    Job = find_worker(Ref, Workers),
-    {noreply, remove_job(Job, St)};
+    case find_worker(Ref, Workers) of
+    #job{} = Job ->
+        {noreply, remove_job(Job, St)};
+    false ->
+        {noreply, St}
+    end;
 
 handle_info({'DOWN', Ref, process, Pid, Error}, #st{workers=Workers} = St) ->
     case find_worker(Ref, Workers) of


### PR DESCRIPTION
This prevents table scans triggered by the kill handler from causing
the server to fall over under very high throughput.

I also took the opportunity to refactor a bit and use #job records
throughout the server instead of raw tuples.

BugzID: 12344
