### PR TITLE
Don't block rexi_server to send an exit message

### DIFF
--- a/src/rexi_server.erl
+++ b/src/rexi_server.erl
@@ -187,4 +187,4 @@ find_worker(Ref, Tab) ->
     case ets:lookup(Tab, Ref) of [] -> false; [Worker] -> Worker end.
 
 notify_caller({Caller, Ref}, Reason) ->
-    Caller ! {Ref, {rexi_EXIT, Reason}}.
+    rexi_utils:send(Caller, {Ref, {rexi_EXIT, Reason}}).

--- a/src/rexi_utils.erl
+++ b/src/rexi_utils.erl
@@ -1,6 +1,17 @@
 -module(rexi_utils).
 
--export([recv/6]).
+-export([send/2, recv/6]).
+
+%% @doc send a message as quickly as possible
+send(Dest, Msg) ->
+    case erlang:send(Dest, Msg, [noconnect, nosuspend]) of
+    noconnect ->
+        spawn(erlang, send, [Dest, Msg]);
+    nosuspend ->
+        spawn(erlang, send, [Dest, Msg]);
+    ok ->
+        ok
+    end.
 
 %% @doc set up the receive loop with an overall timeout
 -spec recv([any()], integer(), function(), any(), timeout(), timeout()) ->


### PR DESCRIPTION
When a worker dies rexi_server needs to notify the remote client.  If communication to the remote node is impaired rexi_server may block for several seconds trying to send the rexi_EXIT message.

Fix is to use the same 'noconnect' and 'nosuspend' options in rexi_server that we use to submit jobs from a client.  Most of the commit is just a refactor to export the `do_send` function as `rexi_utils:send/2`

BugzID: 13298
