### PR TITLE
Reduce stream message limit

### DIFF
--- a/src/rexi.erl
+++ b/src/rexi.erl
@@ -130,7 +130,7 @@ sync_reply(Reply, Timeout) ->
 
 %% @equiv stream(Msg, 100, 300000)
 stream(Msg) ->
-    stream(Msg, 100, 300000).
+    stream(Msg, 10, 300000).
 
 %% @equiv stream(Msg, Limit, 300000)
 stream(Msg, Limit) ->


### PR DESCRIPTION
Its possible that a worker is starved out of running during the initial
spin up of worker processes. When there's a high Q running its possible
that a few of the workers are prevented from sending messages back which
ends up causing significant latency as they wait for other workers to
fill up their 100 message buffer and get swapped out.

Once they start sending though the view streams fine. While we don't
understand why some workers behave like this a quick fix is to just
reduce the size of the buffer so that we're not introducing as large of
a delay in the time to first byte.
