### PR TITLE
Allow called message handlers to return new per message timeout values

### DIFF
--- a/src/rexi_utils.erl
+++ b/src/rexi_utils.erl
@@ -26,6 +26,8 @@ process_mailbox(RefList, Keypos, Fun, Acc0, TimeoutRef, PerMsgTO) ->
         process_mailbox(RefList, Keypos, Fun, Acc, TimeoutRef, PerMsgTO);
     {stop, Acc} ->
         {ok, Acc};
+    {new_timeout, NewTimeout, Acc} ->
+        process_mailbox(RefList, Keypos, Fun, Acc, TimeoutRef, NewTimeout);
     Error ->
         Error
     end.


### PR DESCRIPTION
In some cases messages are intended to be ignored for timeout purposes, .eg. when docs fail
filter tests the controller might want to track those to report to a replicator about progress
but we still want the timeout to be honored. This patch allows the controller to return a new
timeout in this case, namely the remaining time left.

BugzID: 17709
