### PR TITLE
Fix server IDs, add a temporary feature flag

### DIFF
--- a/src/rexi_utils.erl
+++ b/src/rexi_utils.erl
@@ -6,7 +6,7 @@
 server_id(Node) ->
     case config:get("rexi", "server_per_node", "false") of
     "true" ->
-        list_to_atom("rexi_server_" ++ integer_to_list(erlang:phash2(Node)));
+        list_to_atom("rexi_server_" ++ atom_to_list(Node));
     _ ->
         rexi_server
     end.


### PR DESCRIPTION
This PR switches to registered process names of the form `rexi_server_nodename@hostname` and adds a (probably temporary) feature flag to disable the new feature by default.

BugzID: 18215
