### PR TITLE
Don't start rexi_server in start_rexi_servers/0

### DIFF
--- a/src/rexi_server_mon.erl
+++ b/src/rexi_server_mon.erl
@@ -101,7 +101,8 @@ start_rexi_servers() ->
 
 
 missing_servers() ->
-    ServerIds = [rexi_utils:server_id(Node) || Node <- [node() | nodes()]],
+    ServerIds = [rexi_utils:server_id(Node) || Node <- [node() | nodes()],
+        rexi_utils:server_id(Node) =/= rexi_server],
     ChildIds = [Id || {Id, _, _, _} <- supervisor:which_children(?SUP_MODULE)],
     ServerIds -- ChildIds.
 


### PR DESCRIPTION
When per-server rexi_server is disabled (the default), rexi_server_mon
will attempt to start rexi_server every minute as it is not started by
rexi_server_sup.

So don't do that.
