### PR TITLE
Cancel late-arriving streaming workers

### DIFF
--- a/src/rexi_utils.erl
+++ b/src/rexi_utils.erl
@@ -60,7 +60,7 @@ process_message(RefList, Keypos, Fun, Acc0, TimeoutRef, PerMsgTO) ->
         case lists:keyfind(Ref, Keypos, RefList) of
         false ->
             if Msg =:= rexi_STREAM_INIT ->
-                rexi:reply(From, rexi_STREAM_CANCEL);
+                rexi:stream_cancel(From);
             true ->
                 ok
             end,
@@ -80,7 +80,7 @@ process_message(RefList, Keypos, Fun, Acc0, TimeoutRef, PerMsgTO) ->
         case lists:keyfind(Ref, Keypos, RefList) of
         false ->
             if Msg =:= rexi_STREAM_INIT ->
-                rexi:reply(From, rexi_STREAM_CANCEL);
+                rexi:stream_cancel(From);
             true ->
                 ok
             end,


### PR DESCRIPTION
This patch causes rexi's receive loop to cancel any workers that try to initialize a stream when they're not part of the current worker set. Previously we used to ignore them and let them timeout.

The patch is not bulletproof; a worker could initialize a stream after the receive loop has completed.  If the process running the receive loop does not enter another receive loop the worker will eventually timeout. It's an intermediate improvement, though.  Putting it up for comments.

BugzID: 24507
