### PR TITLE
Hibernate rexi_buffer when becoming idle

### DIFF
--- a/src/rexi_buffer.erl
+++ b/src/rexi_buffer.erl
@@ -75,7 +75,16 @@ handle_info(timeout, #state{sender = nil} = State) ->
     if Sender =:= nil, C > 1 ->
         {noreply, State#state{buffer = Q2, count = C-1}, 0};
     true ->
-        {noreply, State#state{buffer = Q2, sender = Sender, count = C-1}}
+        % When Sender is nil and C-1 == 0 we're reverting to an
+        % idle state with no outstanding or queued messages. We'll
+        % use this oppurtunity to hibernate this process and
+        % run a garbage collection.
+        Timeout = case {Sender, C-1} of
+            {nil, 0} -> hibernate;
+            _ -> infinity
+        end,
+        NewState = State#state{buffer = Q2, sender = Sender, count = C-1},
+        {noreply, NewState, Timeout}
     end;
 handle_info(timeout, State) ->
     % Waiting on a sender to return


### PR DESCRIPTION
The rexi_buffer gen_server can hold onto quite a bit of RAM during idle
operation. This just checks when we're going back to the idle state and
hibernates until the next message arrives. This ensures that we run
garbage collection before sitting idle.

BugzId: 27672
