### PR TITLE
Counting bugfix and configurability enhancement for buffers

### DIFF
--- a/src/rexi_buffer.erl
+++ b/src/rexi_buffer.erl
@@ -61,37 +61,25 @@ handle_cast({deliver, Dest, Msg}, #state{buffer = Q, count = C} = State) ->
             {noreply, State#state{buffer = Q2, count = C+1}, 0}
     end.
 
-handle_info(timeout, #state{sender = nil} = State) ->
-    #state{buffer = Q, count = C} = State,
-    Sender = case queue:out_r(Q) of
-        {{value, {Dest, Msg}}, Q2} ->
-            case erlang:send(Dest, Msg, [noconnect, nosuspend]) of
-                ok ->
-                    nil;
-                _Else ->
-                    spawn_monitor(erlang, send, [Dest, Msg])
-            end;
-        {empty, Q2} ->
-            nil
-    end,
-    if Sender =:= nil, C > 1 ->
-        {noreply, State#state{buffer = Q2, count = C-1}, 0};
-    true ->
-        NewState = State#state{buffer = Q2, sender = Sender, count = C-1},
-        % When Sender is nil and C-1 == 0 we're reverting to an
-        % idle state with no outstanding or queued messages. We'll
-        % use this oppurtunity to hibernate this process and
-        % run a garbage collection.
-        case {Sender, C-1} of
-            {nil, 0} ->
-                {noreply, NewState, hibernate};
-            _ ->
-                {noreply, NewState, infinity}
-        end
-    end;
-handle_info(timeout, State) ->
-    % Waiting on a sender to return
+handle_info(timeout, #state{sender = nil, buffer = {[],[]}, count = 0}=State) ->
     {noreply, State};
+handle_info(timeout, #state{sender = nil, count = C} = State) when C > 0 ->
+    #state{buffer = Q, count = C} = State,
+    {{value, {Dest, Msg}}, Q2} = queue:out_r(Q),
+    NewState = State#state{buffer = Q2, count = C-1},
+    case erlang:send(Dest, Msg, [noconnect, nosuspend]) of
+        ok when C =:= 1 ->
+            % We just sent the last queued messsage, we'll use this opportunity
+            % to hibernate the process and run a garbage collection
+            {noreply, NewState, hibernate};
+        ok when C > 1 ->
+            % Use a zero timeout to recurse into this handler ASAP
+            {noreply, NewState, 0};
+        _Else ->
+            % We're experiencing delays, keep buffering internally
+            Sender = spawn_monitor(erlang, send, [Dest, Msg]),
+            {noreply, NewState#state{sender = Sender}}
+    end;
 
 handle_info({'DOWN', Ref, _, Pid, _}, #state{sender = {Pid, Ref}} = State) ->
     {noreply, State#state{sender = nil}, 0}.


### PR DESCRIPTION
Two separate pieces of work here, apologies for the combined PR. The first fixes an edge case counting bug - the patch has been sitting around in FogBugz for several months so I took the opportunity to pull it in.

The second one changes the method we use to decide when to drop a message on the floor. Previously we'd keep buffering until the VM memory exceeded a fixed value. This patch changes the condition to a per-process limit on the _number_ of messages buffered. It also adds the ability to clear the buffer manually. We knowfrom production experience with large clusters that the buffering system can overload a node that rejoins after an absence, so keeping a smaller buffer is likely a smart thing to do here.
