### PR TITLE
Fix error_limit = 0, and make it the default

### DIFF
--- a/src/rexi_server.erl
+++ b/src/rexi_server.erl
@@ -34,7 +34,7 @@
     workers = ets:new(workers, [private, {keypos, #job.worker}]),
     clients = ets:new(clients, [private, {keypos, #job.client}]),
     errors = queue:new(),
-    error_limit = 20,
+    error_limit = 0,
     error_count = 0
 }).
 
@@ -153,6 +153,8 @@ init_p(From, {M,F,A}, Nonce) ->
 
 %% internal
 
+save_error(_E, #st{error_limit = 0} = St) ->
+    St;
 save_error(E, #st{errors=Q, error_limit=L, error_count=C} = St) when C >= L ->
     St#st{errors = queue:in(E, queue:drop(Q))};
 save_error(E, #st{errors=Q, error_count=C} = St) ->


### PR DESCRIPTION
Setting the error_limit to 0 would previously cause rexi_server to crash on the next error because of an unhandled exception in a queue:drop/1. This fixes that exception and makes a limit of 0 the default. Operators
can still raise the limit to capture errors in the future if we end up finding that useful.

BugzID: 30821
