### PR TITLE
Allow for timeout message while waiting for sender

### DIFF
--- a/src/rexi_buffer.erl
+++ b/src/rexi_buffer.erl
@@ -81,6 +81,9 @@ handle_info(timeout, #state{sender = nil, count = C} = State) when C > 0 ->
             Sender = spawn_monitor(erlang, send, [Dest, Msg]),
             {noreply, NewState#state{sender = Sender}}
     end;
+handle_info(timeout, State) ->
+    % Waiting on a sender to return
+    {noreply, State};
 
 handle_info({'DOWN', Ref, _, Pid, _}, #state{sender = {Pid, Ref}} = State) ->
     {noreply, State#state{sender = nil}, 0}.


### PR DESCRIPTION
In 9c36c1b0 we fixed counting bug in the bufffer but introduced another one. We started asserting that the timeout message can only arrive when the sender is not nil, but in fact it can absolutely happen that the buffer is asked to deliver a message while one is in flight. This causes the rexi_buffer to crash. The fix is to simply restore the clause that ignores the timeout message if the server is waiting for a sender to return.

BugzID: 32669

/cc @davisp 
