### PR TITLE
When workers die, send rexi_EXIT message back to coordinating process

### DIFF
--- a/src/rexi.erl
+++ b/src/rexi.erl
@@ -139,6 +139,9 @@ stream_init(Timeout) ->
             couch_stats:increment_counter(
                 [rexi, streams, timeout, init_stream]
             ),
+            rexi:reply({rexi_EXIT, timeout}),
+            % Exit 'normal' to avoid spamming logs. Usually it is because
+            % the coordinator process dies.
             exit(normal);
         Else ->
             exit({invalid_stream_message, Else})
@@ -185,6 +188,9 @@ stream(Msg, Limit, Timeout) ->
             ok
     catch throw:timeout ->
         couch_stats:increment_counter([rexi, streams, timeout, stream]),
+        rexi:reply({rexi_EXIT, timeout}),
+        % Exit 'normal' to avoid spamming logs. Usually it is because
+        % the coordinator process dies.
         exit(normal)
     end.
 
@@ -212,6 +218,9 @@ stream2(Msg, Limit, Timeout) ->
             ok
     catch throw:timeout ->
         couch_stats:increment_counter([rexi, streams, timeout, stream]),
+        rexi:reply({rexi_EXIT, timeout}),
+        % Exit 'normal' to avoid spamming logs. Usually it is because
+        % the coordinator process dies.
         exit(normal)
     end.
 
@@ -257,6 +266,9 @@ init_stream(Timeout) ->
             couch_stats:increment_counter(
                 [rexi, streams, timeout, init_stream]
             ),
+            rexi:reply({rexi_EXIT, timeout}),
+            % Exit 'normal' to avoid spamming logs. Usually it is because
+            % the coordinator process dies.
             exit(normal);
         Else ->
             exit({invalid_stream_message, Else})


### PR DESCRIPTION
Otherwise a coordinating process which uses an infinity timeout (in
particular couch_replicator changes feed process) will never notice a worker
died and will be stuck waiting forever.

In the case of the couch_replicator_manager this would manafest as it not
noticing new replication documents added to the replicator database and
never 'triggering' them.

FB-61505

FB-60382
